### PR TITLE
Upgrade versions of all things but stay on ES 7.x

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:noble
+
+ARG JAVA_VERSION=11.0.23-zulu
+ARG MAVEN_VERSION=3.9.8
+
+SHELL ["/bin/bash", "-c"]
+
+# install prerequisists
+RUN DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt install -y \
+      curl git
+
+ARG USER=ubuntu
+ARG HOME="/home/${USER}"
+USER ${USER}
+
+# install java things
+RUN curl -s "https://get.sdkman.io" | bash \
+    && source ${HOME}/.sdkman/bin/sdkman-init.sh \
+    && sdk install java ${JAVA_VERSION} \
+    && sdk install maven ${MAVEN_VERSION}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-c"]
 RUN DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt install -y \
-      curl git zip unzip
+      curl git zip unzip gnupg
 
 ARG USER=ubuntu
 ARG HOME="/home/${USER}"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-c"]
 RUN DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt install -y \
-      curl git
+      curl git zip unzip
 
 ARG USER=ubuntu
 ARG HOME="/home/${USER}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "esque",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devenv",
+  "workspaceFolder": "/workspaces/esque",
+
+  "postAttachCommand": {
+    "all-maven-install": "find . -type f -name \"pom.xml\" -execdir mvn dependency:resolve \\;",
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,15 @@
+name: esque
+services:
+  devenv:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: esque-devenv
+    volumes:
+      - jbdevcontainer:/.jbdevcontainer
+      - ${HOME}/.ssh:/home/ubuntu/.ssh
+      - ${HOME}/.gitconfig:/home/ubuntu/.gitconfig
+    command: sleep infinity
+
+volumes:
+  jbdevcontainer:

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -22,6 +22,7 @@ jobs:
           server-password: OSSRH_PASSWORD
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           gpg-passphrase: OSSRH_GPG_SECRET_KEY_PASSWORD
+      - run: gpg --version
       - run: mvn -B -ntp versions:set -DnewVersion=$(./version.sh)
       - run: mvn -B -ntp clean deploy
         env:

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -24,7 +24,6 @@ jobs:
           # this sets the wrong variable in settings.xml needed for maven-gpg-plugin since 3.x.x
           # instead you need to set passphraseEnvName in your pom.xml for now
           # gpg-passphrase: OSSRH_GPG_SECRET_KEY_PASSWORD
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - run: cat ~/.m2/settings.xml
       # helps identify build failures due to expired keys
       - run: gpg --list-secret-keys --keyid-format=long

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -24,6 +24,7 @@ jobs:
           # this sets the wrong variable in settings.xml needed for maven-gpg-plugin since 3.x.x
           # instead you need to set passphraseEnvName in your pom.xml for now
           # gpg-passphrase: OSSRH_GPG_SECRET_KEY_PASSWORD
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - run: cat ~/.m2/settings.xml
       # helps identify build failures due to expired keys
       - run: gpg --list-secret-keys --keyid-format=long
@@ -32,4 +33,5 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          OSSRH_GPG_SECRET_KEY_PASSWORD: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+#          OSSRH_GPG_SECRET_KEY_PASSWORD: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -21,10 +21,6 @@ jobs:
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-          # this sets the wrong variable in settings.xml needed for maven-gpg-plugin since 3.x.x
-          # instead you need to set passphraseEnvName in your pom.xml for now
-          # gpg-passphrase: OSSRH_GPG_SECRET_KEY_PASSWORD
-      - run: cat ~/.m2/settings.xml
       # helps identify build failures due to expired keys
       - run: gpg --list-secret-keys --keyid-format=long
       - run: mvn -B -ntp versions:set -DnewVersion=$(./version.sh)
@@ -32,5 +28,7 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-#          OSSRH_GPG_SECRET_KEY_PASSWORD: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+          # this env var needs to be named 'MAVEN_GPG_PASSPHRASE'. if a different name is desired,
+          # it needs to be specified here and in the maven-gpg-plugin configuration variable 'passphraseEnvName'
+          # see issue: https://github.com/actions/setup-java/issues/668
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -23,6 +23,8 @@ jobs:
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           gpg-passphrase: OSSRH_GPG_SECRET_KEY_PASSWORD
       - run: gpg --version
+      - run: cat ~/.m2/settings.xml
+      - run: gpg --list-secret-keys --keyid-format=long
       - run: mvn -B -ntp versions:set -DnewVersion=$(./version.sh)
       - run: mvn -B -ntp clean deploy
         env:

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -10,11 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         with:
+          distribution: 'zulu'
           java-version: 11
           server-id: ossrh
           server-username: OSSRH_USERNAME

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - run: cat ~/.m2/settings.xml
       - run: gpg --list-secret-keys --keyid-format=long
       - run: mvn -B -ntp versions:set -DnewVersion=$(./version.sh)
-      - run: mvn -B -ntp clean deploy
+      - run: mvn -B -X -ntp clean deploy
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -21,12 +21,14 @@ jobs:
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-          gpg-passphrase: OSSRH_GPG_SECRET_KEY_PASSWORD
-      - run: gpg --version
+          # this sets the wrong variable in settings.xml needed for maven-gpg-plugin since 3.x.x
+          # instead you need to set passphraseEnvName in your pom.xml for now
+          # gpg-passphrase: OSSRH_GPG_SECRET_KEY_PASSWORD
       - run: cat ~/.m2/settings.xml
+      # helps identify build failures due to expired keys
       - run: gpg --list-secret-keys --keyid-format=long
       - run: mvn -B -ntp versions:set -DnewVersion=$(./version.sh)
-      - run: mvn -B -X -ntp clean deploy
+      - run: mvn -B -ntp clean deploy
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/esque-core/pom.xml
+++ b/esque-core/pom.xml
@@ -13,54 +13,56 @@
 
     <dependencies>
         <dependency>
+            <!-- todo build two versions. one for 7.x and one for 8.x -->
+            <!-- todo: rest client is deprecated -->
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
-            <version>7.9.3</version>
+            <version>7.17.23</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.11.3</version>
+            <version>2.17.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-parameter-names</artifactId>
-            <version>2.11.3</version>
+            <version>2.17.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.11.3</version>
+            <version>2.17.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.11.3</version>
+            <version>2.17.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.11.3</version>
+            <version>2.17.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>2.0.15</version>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
+            <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.5.6</version>
             <optional>true</optional>
             <scope>test</scope>
         </dependency>

--- a/esque-core/pom.xml
+++ b/esque-core/pom.xml
@@ -14,7 +14,6 @@
     <dependencies>
         <dependency>
             <!-- todo build two versions. one for 7.x and one for 8.x -->
-            <!-- todo: rest client is deprecated -->
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
             <version>7.17.23</version>

--- a/esque-core/src/main/java/org/loesak/esque/core/concurrent/ElasticsearchDocumentLock.java
+++ b/esque-core/src/main/java/org/loesak/esque/core/concurrent/ElasticsearchDocumentLock.java
@@ -11,7 +11,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /*
- * Modeled after the Spring Lock implmentations for JDBC (mostly), Zookeeper, and Redis found here:
+ * Modeled after the Spring Lock implementation for JDBC (mostly), Zookeeper, and Redis found here:
  * https://github.com/spring-projects/spring-integration/blob/master/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java#L102
  * https://github.com/spring-projects/spring-integration/blob/master/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java#L216
  * https://github.com/spring-projects/spring-integration/blob/master/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java#L181

--- a/esque-examples/esque-example-core-es-auth/pom.xml
+++ b/esque-examples/esque-example-core-es-auth/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.5.6</version>
         </dependency>
     </dependencies>
 

--- a/esque-examples/esque-example-core-simple/pom.xml
+++ b/esque-examples/esque-example-core-simple/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.5.6</version>
         </dependency>
     </dependencies>
 

--- a/esque-examples/pom.xml
+++ b/esque-examples/pom.xml
@@ -25,7 +25,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -80,10 +80,10 @@
                 <version>3.2.4</version>
                 <configuration>
                     <bestPractices>true</bestPractices>
-                    <gpgArguments>
-                        <arg>--pinentry-mode</arg>
-                        <arg>loopback</arg>
-                    </gpgArguments>
+<!--                    <gpgArguments>-->
+<!--                        <arg>&#45;&#45;pinentry-mode</arg>-->
+<!--                        <arg>loopback</arg>-->
+<!--                    </gpgArguments>-->
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -80,10 +80,11 @@
                 <version>3.2.4</version>
                 <configuration>
                     <bestPractices>true</bestPractices>
-                    <gpgArguments>
-                        <arg>--pinentry-mode</arg>
-                        <arg>loopback</arg>
-                    </gpgArguments>
+                    <passphraseEnvName>OSSRH_GPG_SECRET_KEY_PASSWORD</passphraseEnvName>
+<!--                    <gpgArguments>-->
+<!--                        <arg>&#45;&#45;pinentry-mode</arg>-->
+<!--                        <arg>loopback</arg>-->
+<!--                    </gpgArguments>-->
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.8.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
                 <version>3.2.4</version>
                 <configuration>
                     <bestPractices>true</bestPractices>
+                    <useAgent>false</useAgent>
 <!--                    <gpgArguments>-->
 <!--                        <arg>&#45;&#45;pinentry-mode</arg>-->
 <!--                        <arg>loopback</arg>-->

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
                 <version>3.2.4</version>
                 <configuration>
                     <bestPractices>true</bestPractices>
-<!--                    <passphraseEnvName>OSSRH_GPG_SECRET_KEY_PASSWORD</passphraseEnvName>-->
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
+                <version>3.2.4</version>
                 <configuration>
+                    <bestPractices>true</bestPractices>
                     <gpgArguments>
                         <arg>--pinentry-mode</arg>
                         <arg>loopback</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,6 @@
                 <configuration>
                     <bestPractices>true</bestPractices>
                     <passphraseEnvName>OSSRH_GPG_SECRET_KEY_PASSWORD</passphraseEnvName>
-<!--                    <gpgArguments>-->
-<!--                        <arg>&#45;&#45;pinentry-mode</arg>-->
-<!--                        <arg>loopback</arg>-->
-<!--                    </gpgArguments>-->
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
                 <version>3.2.4</version>
                 <configuration>
                     <bestPractices>true</bestPractices>
-                    <passphraseEnvName>OSSRH_GPG_SECRET_KEY_PASSWORD</passphraseEnvName>
+<!--                    <passphraseEnvName>OSSRH_GPG_SECRET_KEY_PASSWORD</passphraseEnvName>-->
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,10 @@
                 <version>3.2.4</version>
                 <configuration>
                     <bestPractices>true</bestPractices>
-                    <useAgent>false</useAgent>
-<!--                    <gpgArguments>-->
-<!--                        <arg>&#45;&#45;pinentry-mode</arg>-->
-<!--                        <arg>loopback</arg>-->
-<!--                    </gpgArguments>-->
+                    <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Just finally getting back to this.

This updates version of almost all dependencies to their latest versions. This does update the elasticsearch client version but it keeps it at latest version supporting Elasticsearch version 7.x.

Additionally it adds dev containers for development purposes.

Also had to make changes to GPG signing due to breaking changes in the maven-gpg-plugin and incompatibilities with GitHub's Java action.