### PR TITLE
Upgrade all dependencies to latest versions

### DIFF
--- a/esque-core/build.gradle.kts
+++ b/esque-core/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 dependencies {
     implementation(libs.kotlin.stdlib)
     api(libs.elasticsearch.rest.client)
+    implementation(platform(libs.jackson.bom))
     implementation(libs.jackson.databind)
     implementation(libs.jackson.module.kotlin)
-    implementation(libs.jackson.datatype.jsr310)
     implementation(libs.jackson.dataformat.yaml)
     implementation(libs.kotlin.logging.jvm)
     implementation(libs.slf4j.api)

--- a/esque-core/pom.xml
+++ b/esque-core/pom.xml
@@ -87,7 +87,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.6</version>
                 <executions>
                     <execution>
                         <goals>

--- a/esque-core/pom.xml
+++ b/esque-core/pom.xml
@@ -25,19 +25,15 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
+            <groupId>tools.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 

--- a/esque-core/src/main/kotlin/org/loesak/esque/core/elasticsearch/RestClientOperations.kt
+++ b/esque-core/src/main/kotlin/org/loesak/esque/core/elasticsearch/RestClientOperations.kt
@@ -1,11 +1,10 @@
 package org.loesak.esque.core.elasticsearch
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.core.type.TypeReference
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.http.entity.ContentType
 import org.apache.http.entity.InputStreamEntity
@@ -27,12 +26,11 @@ internal class RestClientOperations(
     private val migrationKey: String,
 ) : Closeable {
 
-    private val mapper = jacksonObjectMapper().apply {
-        registerModule(JavaTimeModule())
-        disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-        disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-        setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    }
+    private val mapper = JsonMapper.builder()
+        .addModule(KotlinModule.Builder().build())
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_NULL) }
+        .build()
 
     override fun close() {
         client.close()

--- a/esque-core/src/main/kotlin/org/loesak/esque/core/yaml/MigrationFileLoader.kt
+++ b/esque-core/src/main/kotlin/org/loesak/esque/core/yaml/MigrationFileLoader.kt
@@ -1,8 +1,7 @@
 package org.loesak.esque.core.yaml
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import tools.jackson.dataformat.yaml.YAMLMapper
+import tools.jackson.module.kotlin.KotlinModule
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.loesak.esque.core.yaml.model.MigrationFile
 import java.nio.ByteBuffer
@@ -36,7 +35,9 @@ internal class MigrationFileLoader {
         private const val MIGRATION_DEFINITION_FILE_NAME_REGEX = "^V((\\d+\\.?)+)__(\\w+)\\.yml$"
         private val FILE_NAME_PATTERN = Regex(MIGRATION_DEFINITION_FILE_NAME_REGEX)
 
-        private val YAML_MAPPER = ObjectMapper(YAMLFactory()).registerModule(KotlinModule.Builder().build())
+        private val YAML_MAPPER = YAMLMapper.builder()
+            .addModule(KotlinModule.Builder().build())
+            .build()
         private val MESSAGE_DIGEST: MessageDigest = MessageDigest.getInstance("MD5")
 
         private fun read(path: Path): MigrationFile {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 kotlin = "2.4.0"
-jackson = "2.22.0"
+jackson = "3.1.4"
 elasticsearch-client = "9.4.2"
 kotlin-logging = "8.0.4"
 slf4j = "2.0.18"
 logback = "1.5.34"
-junit = "5.14.4"
+junit = "6.1.0"
 assertj = "3.27.7"
 testcontainers = "2.0.5"
 vanniktech-publish = "0.36.0"
@@ -13,13 +13,13 @@ vanniktech-publish = "0.36.0"
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
 elasticsearch-rest-client = { module = "org.elasticsearch.client:elasticsearch-rest-client", version.ref = "elasticsearch-client" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
-jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
-jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
-jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
+jackson-databind = { module = "tools.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-module-kotlin = { module = "tools.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+jackson-dataformat-yaml = { module = "tools.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 kotlin-logging-jvm = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+jackson-bom = { module = "tools.jackson:jackson-bom", version.ref = "jackson" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 kotlin = "2.4.0"
-jackson = "2.21.4"
+jackson = "2.22.0"
 elasticsearch-client = "9.4.2"
 kotlin-logging = "8.0.4"
 slf4j = "2.0.18"
 logback = "1.5.34"
-junit = "5.12.1"
+junit = "5.14.4"
 assertj = "3.27.7"
-testcontainers = "2.0.3"
+testcontainers = "2.0.5"
 vanniktech-publish = "0.36.0"
 
 [libraries]

--- a/pom.xml
+++ b/pom.xml
@@ -56,16 +56,16 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
+                <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.22.0</version>
+                <version>3.1.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.14.4</version>
+                <version>6.1.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,21 +58,21 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.21.4</version>
+                <version>2.22.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.12.1</version>
+                <version>5.14.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>2.0.3</version>
+                <version>2.0.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -127,7 +127,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.6</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.11.2</version>
+                <version>3.12.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -158,7 +158,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.2.7</version>
+                <version>3.2.8</version>
                 <configuration>
                     <bestPractices>true</bestPractices>
                 </configuration>


### PR DESCRIPTION
## Summary

- **Jackson 2.22.0 → 3.1.4**: Migrated to new `tools.jackson` groupId, replaced mutable `ObjectMapper` configuration with immutable builder pattern (`JsonMapper.builder()` / `YAMLMapper.builder()`), removed `jackson-datatype-jsr310` (java.time support now built into databind), updated `TypeReference` import
- **JUnit 5.14.4 → 6.1.0**: Bumped version in Gradle catalog and Maven POM; no test code changes needed as `org.junit.jupiter.*` package names are unchanged in JUnit 6
- **jackson-bom 2.21.4 → 2.22.0 → 3.1.4**, **testcontainers 2.0.3 → 2.0.5**, **junit-bom 5.12.1 → 5.14.4 → 6.1.0** (two commits)
- **Maven plugins**: surefire/failsafe 3.5.2 → 3.5.6, javadoc 3.11.2 → 3.12.0, gpg 3.2.7 → 3.2.8
- Skipped pre-release versions: assertj 4.0.0-M1, maven-compiler-plugin 4.0.0-beta-4, maven-source-plugin 4.0.0-beta-1

## Test plan

- [ ] Gradle build (`./gradlew build`) compiles and passes tests
- [ ] Maven build (`mvn clean package -Dgpg.skip=true`) compiles and passes tests
- [ ] CI passes for both Gradle and Maven workflows

---
_Generated by [Claude Code](https://claude.ai/code/session_018NWvWb1niMNf6DMMPrF9Ua)_