### PR TITLE
Upgrade actions/checkout and astral-sh/setup-uv to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   jvm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v4
@@ -32,7 +32,7 @@ jobs:
   python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [jvm, python]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   jvm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v4
@@ -32,10 +32,10 @@ jobs:
   python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.14"
       - working-directory: implementations/python
@@ -67,14 +67,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [jvm, python]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 21
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.14"
       - run: uv sync --project implementations/python


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 to v7 across all three CI jobs (jvm, python, compatibility-tests)
- Bump `astral-sh/setup-uv` from v6 to v7 in the python and compatibility-tests jobs

Both actions were flagged in CI with the warning that they target the deprecated Node.js 20 runtime and are being forced onto Node.js 24. Upgrading to their latest major versions resolves the warning.

## Test plan
- [ ] Confirm CI runs green on this PR with no Node.js deprecation warning


---
_Generated by [Claude Code](https://claude.ai/code/session_01JuDYxDn95tEJiWCk5xKMFt)_