### PR TITLE
Upgrade actions/setup-java to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21


### PR DESCRIPTION
## Summary
- Bump `actions/setup-java` from v4 to v5 in the jvm and compatibility-tests jobs

This was the last action in CI still targeting the deprecated Node.js 20 runtime (flagged by GitHub Actions as being forced onto Node.js 24). Upgrading to v5 resolves the remaining deprecation warning.

## Test plan
- [ ] Confirm CI runs green on this PR with no Node.js deprecation warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01JuDYxDn95tEJiWCk5xKMFt)_