### PR TITLE
Add TypeScript README and update project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is Flyway-esque but for Elasticsearch.
 
 ## Implementations
 
-Esque is available as both a **JVM library** (Kotlin/Java) and a **Python package**.
+Esque is available as a **JVM library** (Kotlin/Java), a **Python package**, and a **TypeScript/npm package**.
 
 ### JVM (Kotlin/Java)
 
@@ -62,7 +62,17 @@ Available on PyPI:
 pip install esque-py
 ```
 
-Both implementations share the same CLI contract, migration file format, checksum algorithm, and ES document structure, so they are interchangeable for any given migration key.
+### TypeScript
+
+Available on npm:
+
+```bash
+npm install esque-ts
+```
+
+Requires Node.js 22+. Also ships a standalone CLI (`npx esque-ts`).
+
+All three implementations share the same CLI contract, migration file format, checksum algorithm, and ES document structure, so they are interchangeable for any given migration key.
 
 ## Migration File Format
 
@@ -106,4 +116,4 @@ Each request supports: `method` (required), `path` (required), `contentType`, `p
 
 - No rollback on failure
 - No "always run" migrations
-- Esque tracks history per `migrationKey` — different implementations writing to the same key must use the same checksum algorithm (both do; they use JSON canonical MD5)
+- Esque tracks history per `migrationKey` — different implementations writing to the same key must use the same checksum algorithm (all do; they use JSON canonical MD5)

--- a/implementations/typescript/README.md
+++ b/implementations/typescript/README.md
@@ -1,0 +1,108 @@
+# esque-ts
+
+TypeScript implementation of [Esque](../../README.md) — an Elasticsearch migration management library.
+
+## Installation
+
+```bash
+npm install esque-ts
+```
+
+Requires Node.js 22+ and Elasticsearch 9+.
+
+## Usage
+
+```typescript
+import { Client } from "@elastic/elasticsearch";
+import { Esque, createEsqueConfiguration } from "esque-ts";
+
+const configuration = createEsqueConfiguration({
+  migrationKey: "my-service",
+  migrationUser: "deploy-bot",            // optional
+  migrationDirectory: "file:./migrations", // optional, default "file:es.migration"
+  lockTimeoutMinutes: 5,                   // optional, default 5
+});
+
+const properties = {
+  indexName: "my-index", // available as #{indexName} in migration files
+};
+
+const esque = new Esque(new Client({ node: "http://localhost:9200" }), configuration, properties);
+try {
+  await esque.execute();
+} finally {
+  await esque.close();
+}
+```
+
+`Esque` also implements `Symbol.asyncDispose`, so it works with `await using` where your TypeScript/Node version supports explicit resource management:
+
+```typescript
+await using esque = new Esque(new Client({ node: "http://localhost:9200" }), configuration, properties);
+await esque.execute();
+```
+
+`close()` releases the Elasticsearch client and any held distributed lock. `execute()` throws an `Error` (with the underlying failure attached via `.cause`) on failure.
+
+#### `EsqueConfiguration` fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `migrationKey` | `string` | required | Unique key scoping all migration records for this service |
+| `migrationUser` | `string \| null` | `null` | Label stored on each applied migration record |
+| `migrationDirectory` | `string` | `"file:es.migration"` | Path to migration files, prefixed with `file:` |
+| `lockTimeoutMinutes` | `number` | `5` | Distributed lock acquisition timeout |
+
+## CLI
+
+esque-ts also ships a standalone CLI (`bin: esque`):
+
+```bash
+npx esque-ts \
+  --es-url=http://localhost:9200 \
+  --migrations-dir=./migrations \
+  --migration-key=my-service \
+  --migration-user=deploy-bot \
+  --lock-timeout-minutes=5 \
+  --property=indexName=my-index
+```
+
+`--property` is repeatable for multiple template variables. Exits `1` and prints the full error chain to stderr on failure.
+
+## How It Works
+
+On each `execute()` call, esque:
+
+1. Creates the internal `.esque` index in Elasticsearch if it does not already exist.
+2. Discovers and parses YAML migration files from `migrationDirectory`, sorted by version.
+3. Validates that all `#{varName}` template references have a matching entry in `properties`.
+4. Resolves templates and computes a checksum for each migration file.
+5. Loads the applied migration history from Elasticsearch for `migrationKey`.
+6. Verifies integrity — checksums, versions, and ordering of previously applied migrations must match the files on disk.
+7. For each unapplied migration, acquires a distributed lock, executes the HTTP requests defined in the file, records the result, and releases the lock.
+
+The distributed lock uses Elasticsearch's `op_type=create` to ensure only one process runs a given migration at a time, making it safe to run concurrently across multiple instances.
+
+## Development
+
+```bash
+cd implementations/typescript
+
+# Install dependencies
+npm install
+
+# Run tests
+npm test
+
+# Format
+npm run format
+
+# Lint
+npm run lint
+
+# Type check
+npm run typecheck
+
+# Build (emits dist/)
+npm run build
+```

--- a/implementations/typescript/src/esque.ts
+++ b/implementations/typescript/src/esque.ts
@@ -1,6 +1,10 @@
 import type { Client } from "@elastic/elasticsearch";
 import type { EsqueConfiguration } from "./configuration.js";
 import type { MigrationRecord } from "./elasticsearch/documents.js";
+
+export type { EsqueConfiguration } from "./configuration.js";
+export { createEsqueConfiguration } from "./configuration.js";
+
 import { ElasticsearchDocumentLock, LockNotHeldError } from "./elasticsearch/lock.js";
 import { RestClientOperations } from "./elasticsearch/operations.js";
 import { MigrationFileLoader } from "./migration/loader.js";


### PR DESCRIPTION
## Summary
- Adds `implementations/typescript/README.md`, mirroring the existing JVM/Python implementation READMEs (installation, library usage, CLI usage, `EsqueConfiguration` fields, how-it-works, development commands).
- Updates the root `README.md`'s Implementations section to include TypeScript/npm alongside JVM and Python, and fixes leftover "both implementations" language now that there are three.
- Re-exports `EsqueConfiguration`/`createEsqueConfiguration` from `implementations/typescript/src/esque.ts` (the package's single entry point) so the library-usage example in the new README actually works via `import { Esque, createEsqueConfiguration } from "esque-ts"` — previously only `Esque` was reachable from the package root.

## Test plan
- [x] `npm run typecheck && npm run build` — confirmed the new re-exports compile and are importable from `dist/esque.js`
- [x] `npm run lint && npm test` — 56/56 unit tests pass, no regressions
- [x] Full pre-commit hook (JVM + Python + TypeScript checks + 52-scenario compatibility suite against a live Elasticsearch container) passed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)